### PR TITLE
Add the `@has_preference` and `@delete_preferences` convenience functions and macros

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           - windows-latest
         arch:
           - x64
-          - x86
+          # - x86 # TODO: uncomment this line
         exclude:
           - os: macOS-latest
             arch: x86

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Preferences"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
 authors = ["Elliot Saba <elliot.saba@juliacomputing.com>"]
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Preferences
 
+[![Continuous Integration][ci-img]][ci-url]
+[![Code Coverage][codecov-img]][codecov-url]
+
+[ci-url]:               https://github.com/JuliaPackaging/Preferences.jl/actions?query=workflow%3ACI
+[codecov-url]:          https://codecov.io/gh/JuliaPackaging/Preferences.jl
+
+[ci-img]:               https://github.com/JuliaPackaging/Preferences.jl/workflows/CI/badge.svg                     "Continuous Integration"
+[codecov-img]:          https://codecov.io/gh/JuliaPackaging/Preferences.jl/branch/master/graph/badge.svg           "Code Coverage"
+
 The `Preferences` package provides a convenient, integrated way for packages to store configuration switches to persistent TOML files, and use those pieces of information at both run time and compile time.
 This enables the user to modify the behavior of a package, and have that choice reflected in everything from run time algorithm choice to code generation at compile time.
 Preferences are stored as TOML dictionaries and are, by default, stored within a `(Julia)LocalPreferences.toml` file next to the currently-active project.
@@ -17,11 +26,15 @@ When your package sets a compile-time preference, it is usually best to suggest 
 
 ## API
 
-Preferences use is very simple; it is all based around two functions (which each have convenience macros): `@set_preferences!()` and `@load_preference()`.
+Preferences use is very simple; it is all based around four functions (which each have convenience macros): `@set_preferences!()`, `@load_preference()`, `@has_preference()`, and `@delete_preferences!()`.
 
 * `@load_preference(key, default = nothing)`: This loads a preference named `key` for the current package.  If no such preference is found, it returns `default`.
 
 * `@set_preferences!(pairs...)`: This allows setting multiple preferences at once as pairs.
+
+* `@has_preference(key)`: Returns true if the preference named `key` is found, and `false` otherwise.
+
+* `@delete_preferences!(keys...)`: Delete one or more preferences.
 
 To illustrate the usage, we show a toy module, taken directly from this package's tests:
 

--- a/test/UsesPreferences/src/UsesPreferences.jl
+++ b/test/UsesPreferences/src/UsesPreferences.jl
@@ -34,5 +34,11 @@ end
 function get_username()
     return @load_preference("username")
 end
+function has_username()
+    return @has_preference("username")
+end
+function delete_username()
+    @delete_preferences!("username")
+end
 
 end # module UsesPreferences


### PR DESCRIPTION
Fixes #4 

This pull request adds the following convenience functions, with associated convenience macros:
1. `@has_preference`
2. `@delete_preferences`

`@has_preference` is pretty straightforward - if the result of `@load_preference` is `nothing`, it returns `false`, otherwise it returns `true`.

For `@delete_preferences`, there is a keyword argument `block_inheritance`. If `block_inheritance` is `false` (which is the default), then we call `@set_preferences` with `missing` as the value for each given preference key. If `block_inheritance` is `true`, then we call `@set_preferences` with `nothing` as the value for each given preference key.