### PR TITLE
Allow `Preferences.jl` to be installed on Julia v1.0+

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Preferences"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
 authors = ["Elliot Saba <elliot.saba@juliacomputing.com>"]
-version = "1.1.0"
+version = "1.2.0"
 
 [deps]
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
@@ -13,4 +13,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 test = ["Test"]
 
 [compat]
-julia = "1.6"
+julia = "1.0"

--- a/src/Preferences.jl
+++ b/src/Preferences.jl
@@ -3,6 +3,10 @@ module Preferences
 using TOML
 using Base: UUID, TOMLCache
 
+if VERSION < v"1.6.0-DEV"
+    error("Preferences.jl can only be used on Julia v1.6+!")
+end
+
 export load_preference, @load_preference,
        has_preference, @has_preference,
        set_preferences!, @set_preferences!,


### PR DESCRIPTION
Even though it can be installed, it won't be loadable.  This is to allow
JLL packages to maintain backwards compatibility, while also also
enabling new featuers on Julia v1.6+