### PR TITLE
Properly escape splatted args

### DIFF
--- a/src/Preferences.jl
+++ b/src/Preferences.jl
@@ -253,7 +253,7 @@ so for setting the preferences in other packages, pending private dependencies.
 """
 macro set_preferences!(prefs...)
     return quote
-        set_preferences!($(esc(get_uuid(__module__))), $(esc(prefs...)), force=true)
+        set_preferences!($(esc(get_uuid(__module__))), $(map(esc,prefs)...), force=true)
     end
 end
 
@@ -286,7 +286,7 @@ so for deleting the preferences in other packages, pending private dependencies.
 """
 macro delete_preferences!(prefs...)
     return quote
-        delete_preferences!($(esc(get_uuid(__module__))), $(esc(prefs...)), force=true)
+        delete_preferences!($(esc(get_uuid(__module__))), $(map(esc,prefs)...), force=true)
     end
 end
 

--- a/test/UsesPreferences/src/UsesPreferences.jl
+++ b/test/UsesPreferences/src/UsesPreferences.jl
@@ -7,12 +7,12 @@ function set_backend(new_backend::String)
     end
 
     # Set it in our runtime values, as well as saving it to disk
-    @set_preferences!("backend" => new_backend)
+    @set_preferences!("backend" => new_backend, "extra" => "tada")
     @info("New backend set; restart your Julia session for this change to take effect!")
 end
 
 function clear_backend()
-    @set_preferences!("backend" => nothing)
+    @set_preferences!("backend" => nothing, "extra" => nothing)
     @info("Backend cleared; restart your Julia session for this change to take effect!")
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,7 +69,7 @@ up_path = joinpath(@__DIR__, "UsesPreferences")
             UsesPreferences.clear_backend()
         """)
         prefs = TOML.parsefile(local_prefs_toml)
-        @test prefs["UsesPreferences"]["__clear__"] == ["backend"]
+        @test prefs["UsesPreferences"]["__clear__"] == ["backend", "extra"]
 
         # Next, change a setting
         activate_and_run(up_path, """


### PR DESCRIPTION
calling `@set_preferences!` with multiple args is currently broken.