### PR TITLE
Version 1.2.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Preferences"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
 authors = ["Elliot Saba <elliot.saba@juliacomputing.com>", "contributors"]
-version = "1.2.2"
+version = "1.2.3"
 
 [deps]
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"


### PR DESCRIPTION
Closes #25

It looks like all changes since 1.2.2 are bug-fixes, hence the patch-release bump.