### PR TITLE
Add `Pkg.test()` test, fix `Base.preferences_names` bug

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,10 +7,12 @@ version = "1.2.4"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Pkg", "SHA", "Test"]
 
 [compat]
 julia = "1.0"

--- a/src/Preferences.jl
+++ b/src/Preferences.jl
@@ -220,11 +220,20 @@ function set_preferences!(u::UUID, prefs::Pair{String,<:Any}...; export_prefs=fa
         end
     end
 
-    # Finally, save the preferences out to either `Project.toml` or `Preferences.toml`
-    # keyed under that `pkg_name`:
+    # Finally, save the preferences out to either `Project.toml` or
+    # `(Julia)LocalPreferences.toml` keyed under that `pkg_name`:
     target_toml = project_toml
     if !export_prefs
+        # We'll default to calling it `LocalPreferneces.toml`
         target_toml = joinpath(dirname(project_toml), "LocalPreferences.toml")
+
+        # But if there's already a `JuliaLocalPreferneces.toml`, use that.
+        for pref_name in Base.preferences_names
+            maybe_file = joinpath(dirname(project_toml), pref_name)
+            if isfile(maybe_file)
+                target_toml = maybe_file
+            end
+        end
     end
     return set_preferences!(target_toml, pkg_name, prefs...; kwargs...)
 end

--- a/test/PTest/.gitignore
+++ b/test/PTest/.gitignore
@@ -1,0 +1,1 @@
+!/Manifest.toml

--- a/test/PTest/LocalPreferences.toml
+++ b/test/PTest/LocalPreferences.toml
@@ -1,0 +1,2 @@
+[PTest]
+pkg_copied = "Local preference copied over by Pkg.jl"

--- a/test/PTest/Manifest.toml
+++ b/test/PTest/Manifest.toml
@@ -1,0 +1,56 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.9.0-DEV"
+manifest_format = "2.0"
+project_hash = "a9bd36dd478c19e6703288ce7bd17915aeab7b1e"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[deps.Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+path = "../.."
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.2.4"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[deps.Random]]
+deps = ["SHA", "Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.0"
+
+[[deps.Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/test/PTest/Project.toml
+++ b/test/PTest/Project.toml
@@ -1,0 +1,10 @@
+name = "PTest"
+uuid = "8789f892-390a-4776-818f-b9c2b248add9"
+version = "0.1.0"
+
+[deps]
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[preferences.PTest]
+pkg_copied_exported = "Exported preference copied over by Pkg.jl"

--- a/test/PTest/src/PTest.jl
+++ b/test/PTest/src/PTest.jl
@@ -9,9 +9,15 @@ function do_test()
     set_preferences!(@__MODULE__, "dynamic_exported" => "Local preference just exported"; export_prefs = true)
     @test @load_preference("dynamic_exported", default = nothing) == "Local preference just exported"
 
-    @test @load_preference("pkg_copied_exported", default = nothing) == "Exported preference copied over by Pkg.jl"
-    @test @load_preference("pkg_copied", default = nothing) == "Local preference copied over by Pkg.jl"
     @test @load_preference("set_by_runtests", default = nothing) == "This was set by runtests.jl"
+   
+    # Pkg handling preferences correctly only came into being in v1.8.0:
+    # X-ref: https://github.com/JuliaLang/Pkg.jl/commit/e7f1659abd7ae93ce2fbaab491873624cd24eb01
+    # X-ref: https://github.com/JuliaLang/julia/pull/44140
+    if VERSION >= v"1.8.0-"
+        @test @load_preference("pkg_copied_exported", default = nothing) == "Exported preference copied over by Pkg.jl"
+        @test @load_preference("pkg_copied", default = nothing) == "Local preference copied over by Pkg.jl"
+    end
 end
 
 end # module PTest

--- a/test/PTest/src/PTest.jl
+++ b/test/PTest/src/PTest.jl
@@ -1,0 +1,17 @@
+module PTest
+
+using Test, Preferences
+
+function do_test()
+    @set_preferences!("dynamic" => "Local preference set just now")
+    @test @load_preference("dynamic", default = nothing) == "Local preference set just now"
+
+    set_preferences!(@__MODULE__, "dynamic_exported" => "Local preference just exported"; export_prefs = true)
+    @test @load_preference("dynamic_exported", default = nothing) == "Local preference just exported"
+
+    @test @load_preference("pkg_copied_exported", default = nothing) == "Exported preference copied over by Pkg.jl"
+    @test @load_preference("pkg_copied", default = nothing) == "Local preference copied over by Pkg.jl"
+    @test @load_preference("set_by_runtests", default = nothing) == "This was set by runtests.jl"
+end
+
+end # module PTest

--- a/test/PTest/test/runtests.jl
+++ b/test/PTest/test/runtests.jl
@@ -1,0 +1,5 @@
+using Test, PTest, Preferences
+
+uuid = Base.UUID("8789f892-390a-4776-818f-b9c2b248add9")
+set_preferences!(uuid, "set_by_runtests" => "This was set by runtests.jl")
+PTest.do_test()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -274,3 +274,17 @@ end
         end
     end
 end
+
+using Pkg, SHA
+@testset "Pkg.test()" begin
+    # Let's test that using `Pkg.test()` on a fake little package works as expected
+    # This package will both expect to read a preference that was defined in the
+    # package's Project.toml and in a LocalPreferneces.toml, as well as attempt to
+    # set and load preferences during the test.  We'll even "export" preferences
+    # during the test and assert that the Project.toml file remains unchanged.
+    project_hash = open(io -> SHA.sha256(io), joinpath(@__DIR__, "PTest", "Project.toml"))
+    Pkg.activate(joinpath(@__DIR__, "PTest")) do
+        Pkg.test()
+    end
+    @test project_hash == open(io -> SHA.sha256(io), joinpath(@__DIR__, "PTest", "Project.toml"))
+end


### PR DESCRIPTION
This ensures that things that users want to do within a `Pkg.test()`
invocation work as expected; they can set and load preferences, they can
read preferences that are set in their package before the test run, and
the test does not modify any local files.