### PR TITLE
Prefer setting preferences only within the currently active project

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Preferences"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
 authors = ["Elliot Saba <elliot.saba@juliacomputing.com>", "contributors"]
-version = "1.2.5"
+version = "1.3.0"
 
 [deps]
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"


### PR DESCRIPTION
Previous to this change, we would search up the environment stack
looking for the project that contains the target package, and set the
preference in there.  This was intended to make it convenient to e.g.
set a `Revise` preference while having an application project activated.
It turns out that the more common problem is actually that a package
wants to set a preference of a sub-package (e.g. `MPI` and
`MPIPreferences`) that may not be a top-level dependent of the currently
active project.

Therefore, we change the behavior of `set_preferences!()` to prefer
adding the target package as an `extras` dependency of the
currently-active project, but maintain the old behavior behind a keyword
argument to `set_preferences!()`.