### PR TITLE
allow setting preferences by package name

### DIFF
--- a/src/Preferences.jl
+++ b/src/Preferences.jl
@@ -32,7 +32,7 @@ function load_preference(uuid::UUID, key::String, default = nothing)
     end
     return drop_clears(get(d, key, default))
 end
-function load_preference(m::Module, key::String, default = nothing)
+function load_preference(m::Union{Module,String}, key::String, default = nothing)
     return load_preference(get_uuid(m), key, default)
 end
 
@@ -58,7 +58,7 @@ function has_preference(uuid::UUID, key::String)
     value = load_preference(uuid, key, nothing)
     return !(value isa Nothing)
 end
-function has_preference(m::Module, key::String)
+function has_preference(m::Union{Module,String}, key::String)
     return has_preference(get_uuid(m), key)
 end
 
@@ -282,7 +282,7 @@ function set_preferences!(u::UUID, prefs::Pair{String,<:Any}...; export_prefs=fa
     end
     return set_preferences!(target_toml, pkg_name, prefs...; kwargs...)
 end
-function set_preferences!(m::Module, prefs::Pair{String,<:Any}...; kwargs...)
+function set_preferences!(m::Union{Module,String}, prefs::Pair{String,<:Any}...; kwargs...)
     return set_preferences!(get_uuid(m), prefs...; kwargs...)
 end
 
@@ -315,7 +315,7 @@ function delete_preferences!(u::UUID, pref_keys::String...; block_inheritance::B
         return set_preferences!(u::UUID, [k => missing for k in pref_keys]...; kwargs...)
     end
 end
-function delete_preferences!(m::Module, pref_keys::String...; kwargs...)
+function delete_preferences!(m::Union{Module,String}, pref_keys::String...; kwargs...)
     return delete_preferences!(get_uuid(m), pref_keys...; kwargs...)
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -10,6 +10,21 @@ function get_uuid(m::Module)
     return uuid
 end
 
+function get_uuid(name::String)
+    for env in Base.load_path()
+        project_toml = Base.env_project_file(env)
+        if !isa(project_toml, String)
+            continue
+        end
+        pkg = Base.project_deps_get(project_toml, name)
+        if pkg === nothing
+            continue
+        end
+        return pkg.uuid
+    end
+    throw(ArgumentError("Package $name is not a dependency of your current environment!"))
+end
+
 function find_first_project_with_uuid(uuid::UUID)
     # Find first element in `Base.load_path()` that contains this UUID
     # This code should look similar to the search in `Base.get_preferences()`


### PR DESCRIPTION
Currently `set_preferences!` and friends can specify the package to update either from a module or UUID. This PR also allows specifying the package by name, provided it is a dependency of some environment in the load path.

This provides the user a convenient way to set preferences on a package before it has been loaded. There are various reasons why you'd want this. For example, the default configuration of a package may not work on some system, preventing the package from ever being loaded. For another example, the default configuration of a package may result in a bunch of downloads (e.g. artifacts) but setting some preferences may use local data instead - and you'd rather avoid those extra unnecessary downloads.

What do you think? I'm happy to put this in another package, but it seems widely useful.

I can add some docs and tests if you're in favour.