### PR TITLE
provide a way to allow Preferences.jl to work on non-package modules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Preferences"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
 authors = ["Elliot Saba <elliot.saba@juliacomputing.com>", "contributors"]
-version = "1.3.0"
+version = "1.4.0"
 
 [deps]
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,13 +1,39 @@
 # Helper function to detect if we're currently compiling
 currently_compiling() = ccall(:jl_generating_output, Cint, ()) != 0
 
+"""
+    Preferences.uuid_cache::Dict{Module,UUID}
+
+Runtime cache to store the UUIDs of root modules.
+Users can make Preferences.jl to work for non-package modules by manually adding a proper
+entry to this cache. It may be useful for debugging or analysis purposes.
+
+```julia
+julia> using Preferences, Pkg
+
+julia> Preferences.uuid_cache[Main] =
+           Pkg.project().dependencies["XXX"]
+
+julia> include("src/XXX.jl") # `Main.XXX` can load configurations for XXX.jl
+```
+
+!!! warning
+    Improper manipulation on this cache may cause unexpected behaviors.
+    Use with care and only as a last resort if absolutely required.
+"""
+const uuid_cache = Dict{Module,UUID}()
+
 # Helper function to get the UUID of a module, throwing an error if it can't.
 function get_uuid(m::Module)
+    rootm = Base.moduleroot(m)
+    if haskey(uuid_cache, rootm)
+        return uuid_cache[rootm]
+    end
     uuid = Base.PkgId(m).uuid
     if uuid === nothing
         throw(ArgumentError("Module $(m) does not correspond to a loaded package!"))
     end
-    return uuid
+    return uuid_cache[rootm] = uuid
 end
 
 function find_first_project_with_uuid(uuid::UUID)

--- a/test/PkgA/.gitignore
+++ b/test/PkgA/.gitignore
@@ -1,0 +1,1 @@
+LocalPreferences.toml

--- a/test/PkgA/Project.toml
+++ b/test/PkgA/Project.toml
@@ -1,5 +1,5 @@
-name = "UsesPreferences"
-uuid = "056c4eb5-4491-6b91-3d28-8fffe3ee2af9"
+name = "PkgA"
+uuid = "056c4eb5-4491-6b91-3d28-8fffe3ee2af1"
 version = "0.1.0"
 
 [deps]

--- a/test/PkgA/src/PkgA.jl
+++ b/test/PkgA/src/PkgA.jl
@@ -1,0 +1,15 @@
+module PkgA
+
+using Preferences
+
+const PkgAConfig = @load_preference("PkgAConfig", false)
+
+function PkgARuntimeConfig_macro()
+    @load_preference("PkgARuntimeConfig", 0)
+end
+
+function PkgARuntimeConfig_func()
+    load_preference(@__MODULE__, "PkgARuntimeConfig", 0)
+end
+
+end # module PkgA

--- a/test/PkgB/.gitignore
+++ b/test/PkgB/.gitignore
@@ -1,0 +1,1 @@
+LocalPreferences.toml

--- a/test/PkgB/Project.toml
+++ b/test/PkgB/Project.toml
@@ -1,5 +1,5 @@
-name = "UsesPreferences"
-uuid = "056c4eb5-4491-6b91-3d28-8fffe3ee2af9"
+name = "PkgB"
+uuid = "056c4eb5-4491-6b91-3d28-8fffe3ee2af2"
 version = "0.1.0"
 
 [deps]

--- a/test/PkgB/src/PkgB.jl
+++ b/test/PkgB/src/PkgB.jl
@@ -1,0 +1,15 @@
+module PkgB
+
+using Preferences
+
+const PkgBConfig = @load_preference("PkgBConfig", false)
+
+function PkgBRuntimeConfig_macro()
+    @load_preference("PkgBRuntimeConfig", 0)
+end
+
+function PkgBRuntimeConfig_func()
+    load_preference(@__MODULE__, "PkgBRuntimeConfig", 0)
+end
+
+end # module PkgA

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Base: UUID
-using Preferences, Test, TOML
+using Preferences, Test, TOML, Pkg, SHA
 
 function activate(f::Function, env_dir::String)
     saved_active_project = Base.ACTIVE_PROJECT[]
@@ -328,7 +328,6 @@ end
     end; end
 end
 
-using Pkg, SHA
 @testset "Pkg.test()" begin
     # Let's test that using `Pkg.test()` on a fake little package works as expected
     # This package will both expect to read a preference that was defined in the
@@ -337,7 +336,68 @@ using Pkg, SHA
     # during the test and assert that the Project.toml file remains unchanged.
     project_hash = open(io -> SHA.sha256(io), joinpath(@__DIR__, "PTest", "Project.toml"))
     Pkg.activate(joinpath(@__DIR__, "PTest")) do
-        Pkg.test()
+        Pkg.test(; io=devnull)
     end
     @test project_hash == open(io -> SHA.sha256(io), joinpath(@__DIR__, "PTest", "Project.toml"))
+end
+
+const PkgA_DIR = normpath(@__DIR__, "PkgA")
+const PkgB_DIR = normpath(@__DIR__, "PkgB")
+function test_with_PkgAB(test_func)
+    old = Pkg.project().path
+    mktempdir() do tempdir
+        try
+            pkgdir = normpath(tempdir, "NonPkgConfig")
+            Pkg.generate(pkgdir; io=devnull)
+            Pkg.activate(pkgdir; io=devnull)
+            Pkg.develop(; path=PkgA_DIR, io=devnull)
+            Pkg.develop(; path=PkgB_DIR, io=devnull)
+
+            local_prefs_toml = normpath(pkgdir, "LocalPreferences.toml")
+            open(local_prefs_toml, "w") do io
+                write(io, """
+                [PkgA]
+                PkgAConfig = true
+                PkgARuntimeConfig = 1
+
+                [PkgB]
+                PkgBConfig = true
+                PkgBRuntimeConfig = 2
+                """)
+            end
+
+            @eval $test_func()
+        finally
+            Pkg.activate(old; io=devnull)
+        end
+    end
+end
+
+@testset "Configuration override for non-package module" begin
+    test_with_PkgAB() do
+        # test the support of configuration override for non-package module
+        try
+            Preferences.main_uuid[] = Pkg.project().dependencies["PkgA"]
+            PkgA = include(normpath(PkgA_DIR, "src", "PkgA.jl"))
+            @test PkgA.PkgAConfig
+            @test 1 == Base.invokelatest(PkgA.PkgARuntimeConfig_macro)
+            @test 1 == Base.invokelatest(PkgA.PkgARuntimeConfig_func)
+        finally
+            Preferences.main_uuid[] = nothing
+        end
+
+        try
+            Preferences.main_uuid[] = Pkg.project().dependencies["PkgB"]
+            PkgB = include(normpath(PkgB_DIR, "src", "PkgB.jl"))
+            @test PkgB.PkgBConfig
+            @test 2 == Base.invokelatest(PkgB.PkgBRuntimeConfig_macro)
+            @test 2 == Base.invokelatest(PkgB.PkgBRuntimeConfig_func)
+
+            # the overridden configuration should persist across the same session
+            @test 1 == Base.invokelatest(PkgA.PkgARuntimeConfig_macro)
+            @test 1 == Base.invokelatest(PkgA.PkgARuntimeConfig_func)
+        finally
+            Preferences.main_uuid[] = nothing
+        end
+    end
 end


### PR DESCRIPTION
The aim of this PR is to provide a way to use Preferences.jl for modules that are defined at runtime. It is useful for for debugging or analysis purposes.

When we want to debug a package code, we may want to run it as top-level script, e.g. <https://github.com/JuliaLang/PrecompileTools.jl/issues/11>
```julia
julia> using PrecompileTools

julia> PrecompileTools.verbose[] = true

julia> include("src/XXX.jl") # run XXX.jl as a script to see what gets precompiled
ERROR: LoadError: ArgumentError: Module Main.XXX does not correspond to a loaded package!
Stacktrace:
 [1] get_uuid(m::Module)
   @ Preferences ~/.julia/packages/Preferences/VmJXL/src/utils.jl:8
 ...
```

Currently this does not work since `get_uuid(m)` throws when `m` is not a proper package (in cases like above, `m` is a submodule of `Main`).

With this commit, we can use `Preferences.uuid_cache` to temporarily make it work:
```julia
julia> using Preferences, Pkg

julia> Preferences.uuid_cache[Main] =
           Pkg.project().dependencies["XXX"]

julia> include("src/XXX.jl")
```

This is not a very clean solution, thus I added docstring that encourages us to use `Preferences.uuid_cache` with care.

This is also useful for analysis packages like JET.jl, which analyzes a package by running its code in the `Main` module.