### PR TITLE
Add documentation via Documenter.jl

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  build-docs:
     permissions:
       contents: write
       statuses: write

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,7 +14,7 @@ jobs:
       statuses: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1.6'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,27 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - master
+    tags: '*'
+  pull_request:
+
+jobs:
+  build:
+    permissions:
+      contents: write
+      statuses: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1.6'
+      - name: Install dependencies
+        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+      - name: Build and deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # If authenticating with SSH deploy key
+        run: julia --project=docs/ docs/make.jl

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,10 +18,7 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1.6'
-      - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-      - name: Build and deploy
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-docdeploy@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # If authenticating with SSH deploy key
-        run: julia --project=docs/ docs/make.jl
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-# Preferences
+# Preferences.jl
 
+[![Docs-stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliapackaging.github.io/Preferences.jl/stable)
+[![Docs-dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliapackaging.github.io/Preferences.jl/dev)
 [![Continuous Integration][ci-img]][ci-url]
 [![Code Coverage][codecov-img]][codecov-url]
+[![License: MIT](https://img.shields.io/badge/License-MIT-success.svg)](https://opensource.org/licenses/MIT)
 
 [ci-url]:               https://github.com/JuliaPackaging/Preferences.jl/actions?query=workflow%3ACI
 [codecov-url]:          https://codecov.io/gh/JuliaPackaging/Preferences.jl
@@ -98,3 +101,12 @@ end
 ```
 Note that these cannot be merged into a single `@static if`. Loading
 the package with `using Preferences` must be done on its own.
+
+## Authors
+This repository was initiated by Elliot Saba
+([@staticfloat](https://github.com/staticfloat)) and continues to be maintained by him and
+other contributors.
+
+## License and contributing
+Preferences.jl is licensed under the MIT license (see [LICENSE.md](LICENSE.md)).
+Contributions by volunteers are welcome!

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,3 @@
+build/
+src/index.md
+src/license.md

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
+
+[compat]
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,55 @@
+using Documenter
+using Preferences
+
+# Copy files and modify them for the docs so that we do not maintain two
+# versions manually.
+open(joinpath(@__DIR__, "src", "index.md"), "w") do io
+  # Point to source license file
+  println(io, """
+  ```@meta
+  EditURL = "https://github.com/JuliaPackaging/Preferences.jl/blob/master/README.md"
+  ```
+  """)
+  # Write the modified contents
+  for line in eachline(joinpath(dirname(@__DIR__), "README.md"))
+    line = replace(line, "[LICENSE.md](LICENSE.md)" => "[License](@ref)")
+    println(io, line)
+  end
+end
+
+open(joinpath(@__DIR__, "src", "license.md"), "w") do io
+  # Point to source license file
+  println(io, """
+  ```@meta
+  EditURL = "https://github.com/JuliaPackaging/Preferences.jl/blob/master/LICENSE.md"
+  ```
+  """)
+  # Write the modified contents
+  println(io, "# License")
+  println(io, "")
+  for line in eachline(joinpath(dirname(@__DIR__), "LICENSE.md"))
+    println(io, "> ", line)
+  end
+end
+
+# Build docs
+makedocs(;
+    sitename = "Preferences.jl",
+    modules = [Preferences],
+    format = Documenter.HTML(
+        prettyurls=get(ENV, "CI", "false") == "true",
+        canonical = "https://juliapackaging.github.io/Preferences.jl/stable"
+    ),
+    pages = [
+        "Home" => "index.md",
+        "Reference" => "reference.md",
+        "License" => "license.md"
+    ]
+)
+
+# Deploy docs
+deploydocs(;
+    repo = "github.com/JuliaPackaging/Preferences.jl.git",
+    devbranch = "master",
+    push_preview = false,
+)

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -1,0 +1,9 @@
+# Reference
+
+```@meta
+CurrentModule = Preferences
+```
+
+```@autodocs
+Modules = [Preferences]
+```


### PR DESCRIPTION
This partially addresses #27.

After having to navigate to the sources of Preferences.jl for the umpteenth time because I forgot the details of the non-macro API, I decided to add Documenter.jl-based documentation. In addition, I added some small bits and pieces to the docs (such as an author and license section).

@staticfloat It would be great if you could set up the `DOCUMENTER_KEY` secret as described in the [Documenter.jl docs](https://documenter.juliadocs.org/stable/man/hosting/#travis-ssh) & review this PR at your convenience. If you want only the bare minimum docs and not the additional changes I made, I can also revert some of them.