### PR TITLE
follow up #62, fix the error of `get_uuid` in the active project lookup path

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -71,11 +71,14 @@ function get_uuid(name::String)
     return load_path_walk() do project_toml
         project = Base.parsed_toml(project_toml)
         if haskey(project, "uuid") && get(project, "name", "") == name
-            return project["uuid"]
+            return parse(Base.UUID, project["uuid"]::String)
         end
-        for key in ["deps", "extras"]
-            if haskey(project, key) && haskey(project[key], name)
-                return parse(Base.UUID, project[key][name])
+        for sect in ["deps", "extras"]
+            if haskey(project, sect)
+                deps = project[sect]::Dict{String,Any}
+                if haskey(deps, name)
+                    return parse(Base.UUID, deps[name]::String)
+                end
             end
         end
         return nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -155,23 +155,36 @@ up_path = joinpath(@__DIR__, "UsesPreferences")
 end
 
 @testset "Loading UUID from Project.toml" begin
-    with_temp_depot() do; mktempdir() do dir
-        activate(dir) do
-            push!(Base.LOAD_PATH, dir)
-            try
-                # Can't do this unless `UsesPreferences` is added as a dep
-                @test_throws ArgumentError Preferences.set_preferences!("UsesPreferences", "location" => "exists")
+    local_prefs_toml = joinpath(up_path, "LocalPreferences.toml")
+    rm(local_prefs_toml; force=true)
 
-                Pkg.develop(;path=up_path)
+    function test_uuid_loading_from_name(switch)
+        with_temp_depot() do; mktempdir() do dir
+            activate(dir) do
+                push!(Base.LOAD_PATH, dir)
+                try
+                    # Can't do this unless `UsesPreferences` is added as a dep
+                    @test_throws ArgumentError Preferences.set_preferences!("UsesPreferences", "location" => "exists")
 
-                # After `dev`'ing `up_path`, it works.
-                Preferences.set_preferences!("UsesPreferences", "location" => "exists")
-                @test load_preference(up_uuid, "location") == "exists"
-            finally
-                pop!(Base.LOAD_PATH)
+                    switch()
+
+                    # After switching `up_path`, it works.
+                    Preferences.set_preferences!("UsesPreferences", "location" => "exists")
+                    @test load_preference(up_uuid, "location") == "exists"
+                finally
+                    pop!(Base.LOAD_PATH)
+                    rm(local_prefs_toml; force=true)
+                end
             end
-        end
-    end; end
+        end; end
+    end
+
+    test_uuid_loading_from_name() do
+        Pkg.develop(; path=up_path) # load UUID with dependency's name
+    end
+    test_uuid_loading_from_name() do
+        Pkg.activate(up_path)       # load UUID with the active project name
+    end
 end
 
 # Load UsesPreferences, as we need it loaded to satisfy `set_preferences!()` below,


### PR DESCRIPTION
Otherwise `set_preferences!(active_project_name::String, ...)` would fail always.